### PR TITLE
Add database backup scripts

### DIFF
--- a/backups/wom-backup.sh
+++ b/backups/wom-backup.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------
+# wom-backup.sh
+#
+# This script performs the removal of old local backups on the WOM
+# server, creates a new backup of the current WOM and WOM bot databases,
+# stores them on the backup server, and prunes old backups from the
+# backup server.
+#
+# Args:
+#   $1 - The host/IP of the remote server.
+#   $2 - The path to the SSH key file to authenticating.
+#   $3 - The local backup directory.
+#   $4 - The remote backup directory.
+#   $5 - How many days worth of backups to keep on the remote server.
+#
+# Example:
+#   $ ./wom-backup.sh \
+#       111.112.113.114 \
+#       /path/to/ssh/private/key \
+#       /path/to/local/backup/dir \
+#       /path/to/remote/backup/dir \
+#       7
+# ----------------------------------------------------------------------
+
+# Errors and exits the script.
+#
+# Args:
+#   $@ - The error message to display before exiting.
+function error {
+    echo "$@";
+    exit 1;
+}
+
+# Generates the JSON for a discord embed.
+#
+# Args:
+#   $@ - The error message to send to discord.
+function generate_embed_json {
+    # Escape quotes and remove newlines
+    DESCRIPTION=$(sed -e 's/"/\\"/g' <<< "$@" | tr -d '\n\r');
+
+    cat <<EOF
+{
+    "username": "WOM Backups",
+    "avatar_url": "https://jonxslays.github.io/wom.py/dev/wom-logo.png",
+    "content": "<@329256344798494773>",
+    "embeds": [{
+        "color": 16720916,
+        "title": "Database Backup Failed",
+        "description": "$DESCRIPTION"
+    }]
+}
+EOF
+}
+
+# Sends a message to the WOM discord if the backup fails for any reason.
+#
+# Args:
+#   $@ - The error message to send to discord.
+function send_webhook_error {
+    # TODO: Add webhook url
+    curl -X POST "" \
+      -H "Content-Type: application/json" \
+      -d "$(generate_embed_json "$@")";
+}
+
+# Checks the last exit code was 0, and exits the program if not.
+#
+# Args:
+#   $@ - The error message to display if the last exit was not 0.
+function check_last_exit {
+    if [ $? -ne 0 ]; then
+        send_webhook_error "$@";
+        error "$@";
+    fi
+}
+
+NUMBER_REGEX='^[0-9]+$';
+if [ -z $1 ]; then
+    # First argument is missing
+    error "ERROR: Remote backup server host/IP is required";
+elif [ -z $2 ]; then
+    # Second argument is missing
+    error "ERROR: Path to SSH private key is required";
+elif [ ! -f $2 ]; then
+    # Second argument isnt a file
+    error "ERROR: Invalid path to SSH private key";
+elif [ -z $3 ]; then
+    # Third argument is missing
+    error "ERROR: Path to local backup dir is required";
+elif [ ! -d $3 ]; then
+    # Third argument isnt a directory
+    error "ERROR: Path to local backup dir is not a directory";
+elif [ -z $4 ]; then
+    # Fourth argument is missing
+    error "ERROR: Path to remote backup dir is required";
+elif [ -z $5 ]; then
+    # Fifth argument is missing
+    error "ERROR: Number of days worth of files to keep is required.";
+elif ! [[ $5 =~ $NUMBER_REGEX ]]; then
+    # A non-numeric was used for prune keep days
+    error "ERROR: Prune keep days must be a number.";
+fi
+
+echo "Starting database backups...";
+REMOTE_HOST=$1;
+SSH_KEY_PATH=$2;
+LOCAL_BACKUP_DIR=$3;
+REMOTE_BACKUP_DIR=$4;
+PRUNE_KEEP_DAYS=$5;
+
+# Dump the WOM bot db into the local directory
+WOM_DB=$(./wom-dump.sh "wise-old-man" $LOCAL_BACKUP_DIR);
+check_last_exit $WOM_DB;
+echo "Dumped WOM db...";
+
+# Dump the discord bot db into the local directory
+BOT_DB=$(./wom-dump.sh "discord-bot" $LOCAL_BACKUP_DIR);
+check_last_exit $BOT_DB;
+echo "Dumped bot db...";
+
+# Upload backups from the local backup dir to remote backup dir
+UPLOAD=$(./wom-upload.sh $REMOTE_HOST $SSH_KEY_PATH $LOCAL_BACKUP_DIR $REMOTE_BACKUP_DIR);
+check_last_exit $UPLOAD;
+echo "Pruned old backups from local server...";
+echo "Backups uploaded to remote server...";
+
+# Prune old backups from the remote server
+PRUNE=$(./wom-prune.sh $REMOTE_BACKUP_DIR $PRUNE_KEEP_DAYS $REMOTE_HOST $SSH_KEY_PATH);
+check_last_exit $PRUNE;
+echo "Pruned old backups from remote server...";
+
+# All went well
+echo "Success!";

--- a/backups/wom-dump.sh
+++ b/backups/wom-dump.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------
+# wom-dump.sh
+#
+# This script dumps the specified database.
+#
+# Args:
+#   $1 - The name of the database that should be dumped.
+#   $2 - The directory where the backup should be stored. This directory
+#        will be created if it does not exist.
+#
+# Example:
+#   $ ./wom-dump.sh wise-old-man_LOCAL /path/to/backup/dir
+# ----------------------------------------------------------------------
+
+# Errors and exits the script.
+#
+# Args:
+#   $@ - The error message to display before exiting.
+function error {
+    echo "ERROR: $@";
+    exit 1;
+}
+
+# Checks the last exit code was 0, and exits the program if not.
+#
+# Args:
+#   $@ - The error message to display if the last exit was not 0.
+function check_last_exit {
+    if [ $? -ne 0 ]; then
+        error "$@";
+    fi
+}
+
+# Gets an environment variables value from docker.
+#
+# Args:
+#   $1 - The environment variable to get without the $ prefix.
+function get_docker_env {
+    docker exec db env | grep -oP "$1=\K.*";
+    check_last_exit "Failed to get $1 from docker environment";
+}
+
+# Dumps the specified database inside docker to the local filesystem.
+#
+# Args:
+#   $1 - The postgres username to connect with.
+#   $2 - The database to dump.
+#   $3 - The path to file to dump to. (will be overwritten if it exists)
+function dump_db {
+    docker exec -it db pg_dump -Fc -U $1 $2 > $3;
+
+    if [ $? -ne 0 ]; then
+        ERROR=$(sed -e 's/"/\"/g' $3);
+        error "Failed to dump. $ERROR";
+    fi
+}
+
+if [ -z $1 ]; then
+    error "Database name is required";
+elif [ -z $2 ]; then
+    error "Backup directory is required";
+fi
+
+BACKUP_DIR=$2;
+DATABASE_NAME=$1;
+POSTGRES_USER=$(get_docker_env "POSTGRES_USER");
+BACKUP_FILE="$DATABASE_NAME-$(date +'%Y-%m-%dT%H:%M:%S').bak";
+BACKUP_PATH="$BACKUP_DIR/$BACKUP_FILE";
+
+mkdir -p $BACKUP_DIR;
+check_last_exit "Failed to create backup directory - $BACKUP_DIR";
+
+dump_db $POSTGRES_USER $DATABASE_NAME $BACKUP_PATH;
+echo "Backup file: $BACKUP_PATH";

--- a/backups/wom-prune.sh
+++ b/backups/wom-prune.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------
+# wom-dump.sh
+#
+# This script connects to the backup server over ssh and prunes backups
+# from the given directory that are older than the given number of days.
+#
+# Args:
+#   $1 - The directory to prune.
+#   $2 - Do not prune files created within this number of days.
+#   $3 - The host/IP of the remote server.
+#   $4 - The path to the SSH key file to authenticating.
+#
+# Example:
+#   $ ./wom-prune.sh \
+#       /path/to/remote/backup/dir \
+#       7 \
+#       111.112.113.114 \
+#       /path/to/ssh/private/key
+# ----------------------------------------------------------------------
+
+# Errors and exits the script.
+#
+# Args:
+#   $@ - The error message to display before exiting.
+function error {
+    echo "ERROR: $@";
+    exit 1;
+}
+
+# Checks the last exit code was 0, and exits the program if not.
+#
+# Args:
+#   $@ - The error message to display if the last exit was not 0.
+function check_last_exit {
+    if [ $? -ne 0 ]; then
+        send_webhook_error "$@";
+        error "$@";
+    fi
+}
+
+NUMBER_REGEX='^[0-9]+$';
+if [ -z $1 ]; then
+    error "Remote directory to prune is required";
+elif [ -z $2 ]; then
+    error "Number of days worth of files to keep is required";
+elif ! [[ $2 =~ $NUMBER_REGEX ]]; then
+    error "Prune keep days must be a number";
+fi
+
+BACKUP_DIR=$1;
+DAYS=$2;
+REMOTE_HOST=$3;
+SSH_KEY_PATH=$4;
+PRUNE="find $BACKUP_DIR -type f -name \"*.bak\" -mtime +$DAYS -exec rm -rdf {} \;";
+
+# Run the prune command on the remote backup server
+ssh root@$REMOTE_HOST -i $SSH_KEY_PATH "bash -s" <<< $PRUNE;
+check_last_exit "Failed to prune remote backup directory";
+echo "Pruning complete...";

--- a/backups/wom-upload.sh
+++ b/backups/wom-upload.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------
+# wom-upload.sh
+#
+# This script uploads the local backups to the remote backup server.
+#
+# Args:
+#   $1 - The host/IP of the remote server.
+#   $2 - The path to the SSH key file to authenticating.
+#   $3 - The local backup directory.
+#   $4 - The remote backup directory.
+#
+# Example:
+#   $ ./wom-upload.sh \
+#       111.112.113.114 \
+#       /path/to/ssh/private/key \
+#       /path/to/local/backup/dir \
+#       /path/to/remote/backup/dir
+# ----------------------------------------------------------------------
+
+# Errors and exits the script.
+#
+# Args:
+#   $@ - The error message to display before exiting.
+function error {
+    echo "ERROR: $@";
+    exit 1;
+}
+
+# Checks the last exit code was 0, and exits the program if not.
+#
+# Args:
+#   $@ - The error message to display if the last exit was not 0.
+function check_last_exit {
+    if [ $? -ne 0 ]; then
+        error "$@";
+    fi
+}
+
+if [ -z $1 ]; then
+    # First argument is missing
+    error "Remote backup server host/IP is required";
+elif [ -z $2 ]; then
+    # Second argument is missing
+    error "Path to SSH private key is required";
+elif [ ! -f $2 ]; then
+    # Second argument isnt a file
+    error "Invalid path to SSH private key";
+elif [ -z $3 ]; then
+    # Third argument is missing
+    error "Path to local backup dir is required";
+elif [ ! -d $3 ]; then
+    # Third argument isnt a directory
+    error "Path to local backup dir is not a directory";
+elif [ -z $4 ]; then
+    # Fourth argument is missing
+    error "Path to remote backup dir is required";
+fi
+
+REMOTE_HOST=$1;
+SSH_KEY_PATH=$2;
+LOCAL_BACKUP_DIR=$3;
+REMOTE_BACKUP_DIR=$4;
+
+# Prune yesterdays local backups
+# find $LOCAL_BACKUP_DIR -type f -name "*.bak" -mtime +1 -exec rm -rdf {} \;
+# NOTE: For now always delete all the local backups to conserve disk space
+# When were ready to keep copies for a day revert to the above ^
+find $LOCAL_BACKUP_DIR -type f -name "*.bak" -exec rm -rdf {} \;
+check_last_exit "Failed to prune the local backup directory";
+
+# Upload remaining backups to the remote server
+rsync -raze "ssh -i $SSH_KEY_PATH" \
+    $LOCAL_BACKUP_DIR/ \
+    root@$REMOTE_HOST:$REMOTE_BACKUP_DIR;
+
+check_last_exit "Failed upload backups to remote server";
+echo "Uploaded to remote backup directory...";


### PR DESCRIPTION
This PR adds 4 scripts for taking backups of the WOM and WOM Bot databases.

- `wom-backup.sh` - This script will run on a cron timer and is the entrypoint for the other scripts.
- `wom-dump.sh` - This script performs the dumping of an individual database.
- `wom-prune.sh` - This script handles pruning old backups from the backup server.
- `wom-upload.sh` - This script handles pruning the local backups and uploading them to the backup server. 

### TODO

- Create an SSH key for the scripts to use to connect from the wom server to the backup server.
- Create a webhook for the scripts to send details of failed backups.

Worth noting that when calling these scripts and passing a directory argument, never include the trailing slash - the scripts take care of that.